### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
           volta install node@latest
           echo "NODE_LATEST=$(volta which node)" >> $GITHUB_ENV
           echo "NODE_LATEST_VERSION=$(node --version)" >> $GITHUB_ENV
-          volta install node@16
+          volta install node@18
           echo "NODE_DEFAULT=$(volta which node)" >> $GITHUB_ENV
           echo "NODE_DEFAULT_VERSION=$(node --version)" >> $GITHUB_ENV
       - name: Install multiple Node versions (Windows)
@@ -37,7 +37,7 @@ jobs:
           volta install node@latest
           echo "NODE_LATEST=$(volta which node)" >> $env:GITHUB_ENV
           echo "NODE_LATEST_VERSION=$(node --version)" >> $env:GITHUB_ENV
-          volta install node@16
+          volta install node@18
           echo "NODE_DEFAULT=$(volta which node)" >> $env:GITHUB_ENV
           echo "NODE_DEFAULT_VERSION=$(node --version)" >> $env:GITHUB_ENV
       - name: Setup dummy ESLint projects

--- a/lib/main.js
+++ b/lib/main.js
@@ -469,7 +469,7 @@ export default {
       return null;
     }
 
-    if (err.type && err.type === 'config-not-found') {
+    if (err.type === 'config-not-found' || err.messageTemplate === 'config-file-missing') {
       if (Config.get('disabling.disableWhenNoEslintConfig')) {
         let { filePath, projectPath } = err;
         if (projectPath && projectPath.length && filePath.startsWith(projectPath)) {

--- a/spec/fixtures/ci/package-interaction/eslint.config.js
+++ b/spec/fixtures/ci/package-interaction/eslint.config.js
@@ -1,0 +1,7 @@
+module.exports = [
+  {
+    rules: {
+      'no-unused-vars': "error"
+    }
+  }
+];

--- a/spec/node-bin-spec.js
+++ b/spec/node-bin-spec.js
@@ -29,6 +29,7 @@ async function writeProjectConfig (projectPath, config) {
 async function copyFilesIntoProject (projectPath) {
   let files = [
     Path.join(fixtureRoot, '.eslintrc'),
+    Path.join(fixtureRoot, 'eslint.config.js'),
     Path.join(fixtureRoot, 'index.js')
   ];
   for (let file of files) {


### PR DESCRIPTION
Two main causes of the CI breakage:

1. Latest ESLint now expects the new config file format, so the fixture directories now include an `eslint.config.js` file.
2. Latest ESLint expects `structuredClone` to be present; it was added in Node 17, so we'll make Node 18 the oldest version of Node we test on.

(I don't think this package needs an official support policy regarding Node; the deal is that, if your version of ESLint (>= version 8) works on the command line for your project, it'll work in this package, since the point is to use the same version of Node to run the worker process as you've got set up for your project.)